### PR TITLE
Use `Chain` in `traverseDirectly` helpers

### DIFF
--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -288,8 +288,8 @@ object Traverse {
 
   private[cats] def traverseDirectly[G[_], A, B](
     fa: IterableOnce[A]
-  )(f: A => G[B])(implicit G: StackSafeMonad[G]): G[Vector[B]] = {
-    fa.iterator.foldLeft(G.pure(Vector.empty[B])) { case (accG, a) =>
+  )(f: A => G[B])(implicit G: StackSafeMonad[G]): G[Chain[B]] = {
+    fa.iterator.foldLeft(G.pure(Chain.empty[B])) { case (accG, a) =>
       G.map2(accG, f(a)) { case (acc, x) =>
         acc :+ x
       }

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -206,8 +206,8 @@ object TraverseFilter {
 
   private[cats] def traverseFilterDirectly[G[_], A, B](
     fa: IterableOnce[A]
-  )(f: A => G[Option[B]])(implicit G: StackSafeMonad[G]): G[Vector[B]] = {
-    fa.iterator.foldLeft(G.pure(Vector.empty[B])) { case (bldrG, a) =>
+  )(f: A => G[Option[B]])(implicit G: StackSafeMonad[G]): G[Chain[B]] = {
+    fa.iterator.foldLeft(G.pure(Chain.empty[B])) { case (bldrG, a) =>
       G.map2(bldrG, f(a)) {
         case (acc, Some(b)) => acc :+ b
         case (acc, None)    => acc

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1245,7 +1245,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
         else
           G match {
             case x: StackSafeMonad[G] =>
-              x.map(Traverse.traverseDirectly(fa.iterator)(f)(x))(fromIterableOnce(_))
+              Traverse.traverseDirectly(fa.iterator)(f)(x)
             case _ =>
               traverseViaChain {
                 val as = collection.mutable.ArrayBuffer[A]()
@@ -1374,7 +1374,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
       else
         G match {
           case x: StackSafeMonad[G] =>
-            x.map(TraverseFilter.traverseFilterDirectly(fa.iterator)(f)(x))(traverse.fromIterableOnce(_))
+            TraverseFilter.traverseFilterDirectly(fa.iterator)(f)(x)
           case _ =>
             traverseFilterViaChain {
               val as = collection.mutable.ArrayBuffer[A]()

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -131,7 +131,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
           case x: StackSafeMonad[G] =>
             x.map(Traverse.traverseDirectly(fa)(f)(x))(_.toList)
           case _ =>
-            G.map(Chain.traverseViaChain(fa.toIndexedSeq)(f))(_.toVector)
+            G.map(Chain.traverseViaChain(fa.toIndexedSeq)(f))(_.toList)
         }
 
       override def traverse_[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -271,7 +271,7 @@ private[instances] trait VectorInstancesBinCompat0 {
 
     def traverseFilter[G[_], A, B](fa: Vector[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Vector[B]] =
       G match {
-        case x: StackSafeMonad[G] => TraverseFilter.traverseFilterDirectly(fa)(f)(x)
+        case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(x))(_.toVector)
         case _ =>
           G.map(Chain.traverseFilterViaChain(fa)(f))(_.toVector)
       }


### PR DESCRIPTION
TLDR: Using `Chain` in `traverseDirectly` helpers is better than using `Vector`.


### The data

Below are comparison tables from JMH runs.
All runs were done with the following:
`bench/jmh:run -i 10 -wi 10 -f 2 -t 1 cats.bench.TraverseBench`
And with the jvmopts: -Xms2G -Xmx12G

The "worst diff" column is the worst case comparison, if the new result was at the bottom of it's error bound, and the old result was at the top.
The "within" column is basically the best case comparison, if this value is positive than we are within error bounds or better.

Comparing `this` (which uses `Chain`) to the latest from PR 4498 (which uses `Vector`):

  | `this` | error | PR 4498 | error | worst diff | within
-- | -- | -- | -- | -- | -- | --
filterList | 5683.922 | 79.338 | 5715.626 | 29.321 | -140.363 | 76.955
filterVector | 5573.414 | 72.463 | 5546.558 | 19.276 | -64.883 | 118.595
mapList | 5806.501 | 54.822 | 5767.038 | 34.619 | -49.978 | 128.904
mapVector | 6172.395 | 34.507 | 6173.065 | 40.277 | -75.454 | 74.114
traverseChain | 1383.903 | 18.172 | 1123.427 | 4.987 | 237.317 | 283.635
traverseChainError | 2404.853 | 12.512 | 2127.662 | 13.144 | 251.535 | 302.847
traverseFilterChain | 1390.162 | 2.67 | 1180.463 | 5.585 | 201.444 | 217.954
traverseFilterList | 1208.214 | 15.235 | 1206.215 | 9.615 | -22.851 | 26.849
traverseFilterVector | 1193.495 | 11.759 | 1244.894 | 25.955 | -89.113 | -13.685
traverseList | 1137.685 | 10.687 | 1069.802 | 13.869 | 43.327 | 92.439
traverseListError | 2511.207 | 20.612 | 2167.488 | 21.981 | 301.126 | 386.312
traverseVector | 1147.222 | 4.087 | 1152.973 | 25.078 | -34.916 | 23.414
traverseVectorError | 2542.108 | 10.112 | 2207.517 | 33.643 | 290.836 | 378.346
traverse_Chain | 7685.159 | 158.094 | 7912.984 | 107.098 | -493.017 | 37.367
traverse_List | 9030.47 | 46.202 | 8934.534 | 46.916 | 2.818 | 189.054
traverse_Vector | 8454.338 | 200.978 | 9092.209 | 36.689 | -875.538 | -400.204

Compairing `this` to cats `main`:

  | `this` | error | `main` | error | worst diff | within
-- | -- | -- | -- | -- | -- | --
filterList | 5683.922 | 79.338 | 5710.935 | 65.052 | -171.403 | 117.377
filterVector | 5573.414 | 72.463 | 5586.684 | 53.06 | -138.793 | 112.253
mapList | 5806.501 | 54.822 | 5794.559 | 31.269 | -74.149 | 98.033
mapVector | 6172.395 | 34.507 | 6156.259 | 29.844 | -48.215 | 80.487
traverseChain | 1383.903 | 18.172 | 1092.33 | 7.171 | 266.23 | 316.916
traverseChainError | 2404.853 | 12.512 | 2713.055 | 41.359 | -362.073 | -254.331
traverseFilterChain | 1390.162 | 2.67 | 982.057 | 6.179 | 399.256 | 416.954
traverseFilterList | 1208.214 | 15.235 | 873.508 | 11.078 | 308.393 | 361.019
traverseFilterVector | 1193.495 | 11.759 | 986.796 | 41.753 | 153.187 | 260.211
traverseList | 1137.685 | 10.687 | 918.397 | 39.014 | 169.587 | 268.989
traverseListError | 2511.207 | 20.612 | 2781.32 | 15.372 | -306.097 | -234.129
traverseVector | 1147.222 | 4.087 | 997.688 | 4.798 | 140.649 | 158.419
traverseVectorError | 2542.108 | 10.112 | 3081.201 | 31.311 | -580.516 | -497.67
traverse_Chain | 7685.159 | 158.094 | 939.052 | 20.897 | 6567.116 | 6925.098
traverse_List | 9030.47 | 46.202 | 808.78 | 8.011 | 8167.477 | 8275.903
traverse_Vector | 8454.338 | 200.978 | 1111.32 | 9.188 | 7132.852 | 7553.184


